### PR TITLE
Made ApplicationId in Logger public

### DIFF
--- a/Rock.Logging.IntegrationTests/LoggerFactoryTests.cs
+++ b/Rock.Logging.IntegrationTests/LoggerFactoryTests.cs
@@ -1,0 +1,19 @@
+﻿using NUnit.Framework;
+using Rock.Conversion;
+
+namespace Rock.Logging.IntegrationTests
+{
+    [TestFixture]
+    public class LoggerFactoryTests
+    {
+        [Test]
+        public void CanSetAppId()
+        {
+            var appId = "foo";
+            Assume.That(ApplicationId.Current != appId, "You've named an application \'foo\', apparently.");
+            var log = LoggerFactory.GetInstance(applicationId: appId);
+            var implCast = (Logger) log;
+            Assert.That(string.Equals(implCast.ApplicationId, appId));
+        }
+    }
+}

--- a/Rock.Logging.IntegrationTests/Rock.Logging.IntegrationTests.csproj
+++ b/Rock.Logging.IntegrationTests/Rock.Logging.IntegrationTests.csproj
@@ -71,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileConfigurationTests.cs" />
+    <Compile Include="LoggerFactoryTests.cs" />
     <Compile Include="LogProviders\RollingFileLogProviderTests.cs" />
     <Compile Include="LogProviders\FileLogProviderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Rock.Logging/Logger.cs
+++ b/Rock.Logging/Logger.cs
@@ -11,7 +11,7 @@ namespace Rock.Logging
         private readonly ILoggerConfiguration _configuration;
         private readonly IEnumerable<ILogProvider> _logProviders;
 
-        private readonly string _applicationId;
+        public string ApplicationId { get; set; }
         
         private readonly ILogProvider _auditLogProvider;
         private readonly IThrottlingRuleEvaluator _throttlingRuleEvaluator;
@@ -46,10 +46,10 @@ namespace Rock.Logging
             _configuration = configuration;
             _logProviders = logProviders;
 
-            _applicationId =
+            ApplicationId =
                 applicationIdProvider != null
                     ? applicationIdProvider.GetApplicationId()
-                    : ApplicationId.Current;
+                    : global::Rock.ApplicationId.Current;
 
             _auditLogProvider = auditLogProvider; // NOTE: this can be null, and is expected.
             _throttlingRuleEvaluator = throttlingRuleEvaluator ?? new NullThrottlingRuleEvaluator();
@@ -79,7 +79,7 @@ namespace Rock.Logging
 
             if (string.IsNullOrWhiteSpace(logEntry.ApplicationId))
             {
-                logEntry.ApplicationId = _applicationId;
+                logEntry.ApplicationId = ApplicationId;
             }
 
             if (logEntry.UniqueId == null)

--- a/Rock.Logging/LoggerFactory.cs
+++ b/Rock.Logging/LoggerFactory.cs
@@ -30,15 +30,6 @@ namespace Rock.Logging
         }
 
         /// <summary>
-        /// Get a the default instance of <see cref="Logger"/>.
-        /// </summary>
-        /// <returns>An instance of <see cref="Logger"/>.</returns>
-        public static ILogger GetInstance()
-        {
-            return GetInstance(null);
-        }
-
-        /// <summary>
         /// Get a the default instance of <typeparamref name="TLogger"/>.
         /// </summary>
         /// <typeparam name="TLogger">The type of <see cref="ILogger"/> to return.</typeparam>
@@ -53,10 +44,16 @@ namespace Rock.Logging
         /// Get an instance of <see cref="Logger"/> for the given category.
         /// </summary>
         /// <param name="categoryName">The category of the logger to retrieve.</param>
+        /// <param name="applicationId">The application that generated the log.</param>
         /// <returns>An instance of <see cref="Logger"/>.</returns>
-        public static ILogger GetInstance(string categoryName)
+        public static ILogger GetInstance(string categoryName = null, string applicationId = null)
         {
-            return Current.Get<Logger>(categoryName);
+            var log = Current.Get<Logger>(categoryName);
+            if (applicationId != null)
+            {
+                log.ApplicationId = applicationId;
+            }
+            return log;
         }
 
         /// <summary>


### PR DESCRIPTION
... and added the ability to override it.

Also, added an optional parameter to LoggerFactory.GetInstance (the non-generic one). When supplied, the logger will use that Id instead of the application's current one-- assuming it's not set in the ILogEntry.