### PR TITLE
Fix HttpClient bug: Don't use and dispose of a new HttpClient for each log

### DIFF
--- a/Rock.Logging/LogProviders/HttpEndpointLogProvider.cs
+++ b/Rock.Logging/LogProviders/HttpEndpointLogProvider.cs
@@ -1,22 +1,41 @@
 ﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 using Rock.Net.Http;
 using Rock.Serialization;
 
 namespace Rock.Logging
 {
-    public class HttpEndpointLogProvider : ILogProvider
+    public class HttpEndpointLogProvider : ILogProvider, IDisposable
     {
         private const string DefaultContentType = "application/json";
+        private const int DefaultAdditionalHttpClientCycleMilliseconds = 0;
 
         private readonly string _endpoint;
         private readonly LogLevel _loggingLevel;
         private readonly string _contentType;
+        private readonly int _additionalHttpClientCycleMilliseconds;
         private readonly ISerializer _serializer;
         private readonly Func<ILogEntry, string> _serializeLogEntry; 
         private readonly IHttpClientFactory _httpClientFactory;
+
+        private readonly Timer _httpClientCycleTimer;
+        private HttpClient _workingHttpClient;
+        private HttpClient _httpClientToDisposeOfNext;
+
+        public HttpEndpointLogProvider(
+            string endpoint,
+            LogLevel loggingLevel,
+            string contentType,
+            ISerializer serializer,
+            IHttpClientFactory httpClientFactory,
+            bool serializeAsConcreteType)
+            : this(endpoint, loggingLevel, contentType, serializer, httpClientFactory,
+                  serializeAsConcreteType, DefaultAdditionalHttpClientCycleMilliseconds)
+        {
+        }
 
         public HttpEndpointLogProvider(
             string endpoint,
@@ -24,7 +43,8 @@ namespace Rock.Logging
             string contentType = DefaultContentType,
             ISerializer serializer = null,
             IHttpClientFactory httpClientFactory = null,
-            bool serializeAsConcreteType = true)
+            bool serializeAsConcreteType = true,
+            int additionalHttpClientCycleMilliseconds = DefaultAdditionalHttpClientCycleMilliseconds)
         {
             _serializer = serializer ?? GetDefaultSerializer();
             _httpClientFactory = httpClientFactory ?? GetDefaultHttpClientFactory();
@@ -32,10 +52,14 @@ namespace Rock.Logging
             _endpoint = endpoint;
             _loggingLevel = loggingLevel;
             _contentType = contentType;
+            _additionalHttpClientCycleMilliseconds = additionalHttpClientCycleMilliseconds;
             _serializeLogEntry =
                 serializeAsConcreteType
                     ? (Func<ILogEntry, string>)(entry => _serializer.SerializeToString(entry, entry.GetType()))
                     : entry => _serializer.SerializeToString(entry);
+
+            _workingHttpClient = _httpClientFactory.CreateHttpClient();
+            _httpClientCycleTimer = new Timer(CycleHttpClient, null, CycleDueTime, Timeout.InfiniteTimeSpan);
         }
 
         public event EventHandler<ResponseReceivedEventArgs> ResponseReceived;
@@ -65,6 +89,14 @@ namespace Rock.Logging
             get { return _httpClientFactory; }
         }
 
+        public int AdditionalHttpClientCycleMilliseconds
+        {
+            get { return _additionalHttpClientCycleMilliseconds; }
+        }
+
+        private TimeSpan CycleDueTime =>
+            _workingHttpClient.Timeout + TimeSpan.FromMilliseconds(1000 + _additionalHttpClientCycleMilliseconds);
+
         public async Task WriteAsync(ILogEntry entry)
         {
             var serializedEntry = _serializeLogEntry(entry);
@@ -72,23 +104,20 @@ namespace Rock.Logging
             var postContent = new StringContent(serializedEntry);
             postContent.Headers.ContentType = new MediaTypeHeaderValue(_contentType);
 
-            using (var httpClient = _httpClientFactory.CreateHttpClient())
+            HttpResponseMessage response;
+
+            try
             {
-                HttpResponseMessage response;
-
-                try
-                {
-                    response = await httpClient.PostAsync(_endpoint, postContent).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    throw new HttpEndpointLogProviderException(
-                        "Error sending serialized log entry via HTTP POST.",
-                        ex, _endpoint, _contentType);
-                }
-
-                OnResponseReceived(response);
+                response = await _workingHttpClient.PostAsync(_endpoint, postContent).ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                throw new HttpEndpointLogProviderException(
+                    "Error sending serialized log entry via HTTP POST.",
+                    ex, _endpoint, _contentType);
+            }
+
+            OnResponseReceived(response);
         }
 
         protected virtual void OnResponseReceived(HttpResponseMessage response)
@@ -108,6 +137,22 @@ namespace Rock.Logging
         private static IHttpClientFactory GetDefaultHttpClientFactory()
         {
             return DefaultHttpClientFactory.Current;
+        }
+
+        private void CycleHttpClient(object state)
+        {
+            var oldHttpClient = Interlocked.Exchange(ref _workingHttpClient, _httpClientFactory.CreateHttpClient());
+            if (_httpClientToDisposeOfNext != null) _httpClientToDisposeOfNext.Dispose();
+            _httpClientToDisposeOfNext = oldHttpClient;
+            _httpClientCycleTimer.Change(CycleDueTime, Timeout.InfiniteTimeSpan);
+        }
+
+        public void Dispose()
+        {
+            _httpClientCycleTimer.Change(Timeout.Infinite, Timeout.Infinite);
+            using (var waitHandle = new AutoResetEvent(false)) if (_httpClientCycleTimer.Dispose(waitHandle)) waitHandle.WaitOne();
+            if (_httpClientToDisposeOfNext != null) _httpClientToDisposeOfNext.Dispose();
+            _workingHttpClient.Dispose();
         }
     }
 }

--- a/Rock.Logging/LogProviders/HttpEndpointLogProvider.cs
+++ b/Rock.Logging/LogProviders/HttpEndpointLogProvider.cs
@@ -12,6 +12,7 @@ namespace Rock.Logging
     {
         private const string DefaultContentType = "application/json";
         private const int DefaultAdditionalHttpClientCycleMilliseconds = 0;
+        private const int HttpClientCyclePaddingMilliseconds = 1000;
 
         private readonly string _endpoint;
         private readonly LogLevel _loggingLevel;
@@ -23,7 +24,7 @@ namespace Rock.Logging
 
         private readonly Timer _httpClientCycleTimer;
         private HttpClient _workingHttpClient;
-        private HttpClient _httpClientToDisposeOfNext;
+        private volatile HttpClient _httpClientToDisposeOfNext;
 
         public HttpEndpointLogProvider(
             string endpoint,
@@ -94,8 +95,10 @@ namespace Rock.Logging
             get { return _additionalHttpClientCycleMilliseconds; }
         }
 
-        private TimeSpan CycleDueTime =>
-            _workingHttpClient.Timeout + TimeSpan.FromMilliseconds(1000 + _additionalHttpClientCycleMilliseconds);
+        private TimeSpan CycleDueTime
+        {
+            get { return _workingHttpClient.Timeout + TimeSpan.FromMilliseconds(HttpClientCyclePaddingMilliseconds + _additionalHttpClientCycleMilliseconds); }
+        }
 
         public async Task WriteAsync(ILogEntry entry)
         {


### PR DESCRIPTION
See http://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

If a new HttpClient is used and disposed of for each log, then we will
end up with port starvation on the machine that is running the app using
HttpEndpointLogProvider. However, if we only ever create one HttpClient,
then the app will bypass load balancing and DNS changes. The middle
ground is to use an HttpClient for some amount of time, then use another
one for some time, then use another one, et cetera. Each time we swap
out for a new HttpClient, we dispose of the one that had been switched
out during the previous swap. That way, any requests that are in process
have a time to finish.